### PR TITLE
remove annotation addition upon creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.4
 
 COPY congress /
 
-ENV CONGRESS_EXCLUDES "kube-system,apigee,apigee-jenkins,calico-system,guardians"
+ENV CONGRESS_EXCLUDES "default,kube-system,apigee,apigee-jenkins,calico-system,guardians"
+ENV CONGRESS_SELECTOR "runtime=shipyard"
 
 CMD ["/congress"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_VERSION=0.1.0
+IMAGE_VERSION=0.1.1
 
 build-and-package: compile-linux build-image
 build-deploy-dev: compile-linux build-image push-to-dev deploy-dev-image

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # congress
 
-`congress` is a k8s Namespace watcher designed to utilize NetworkPolicy objects to create namespace isolation within a cluster. 
+`congress` is a k8s Namespace watcher designed to utilize NetworkPolicy objects to create namespace isolation within a cluster.
 
 **First, this is an Apigee specific implementation.**
 
-All namespace creation events will be evaluated by `congress` and isolated if not specifically excluded. A namespace evaluated by `congress` will be given an `annotation` that locks down all inter/intra-namespace pod traffic. It will also be given a label that is `NetworkPolicy` objects will use to identify the namespace's pod traffic. An example is below.
+All namespace creation events will be evaluated by `congress` and isolated if not specifically excluded. A namespace evaluated by `congress` needs to have an `annotation` that locks down all inter/intra-namespace pod traffic. It will be given a label that it's `NetworkPolicy` objects will use to identify the namespace's pod traffic. An example is below.
 ```yaml
 kind: Namespace
 apiVersion: v1
@@ -13,7 +13,7 @@ metadata:
   labels:
    name: test # added by congress
   annotations:
-    net.beta.kubernetes.io/network-policy: | # added by congress
+    net.beta.kubernetes.io/network-policy: | # necessary for NetworkPolicies to work
       {
         "ingress": {
           "isolation": "DefaultDeny"
@@ -25,7 +25,7 @@ The namespace is also given two `NetworkPolicy` objects that behave as follows:
 * `allow-apigee`: this policy allows pod traffic from the `apigee` namespace (a.k.a an "apigee bridge"). This is necessary for pods running on Apigee's cluster.
 
 ##Environment
-There are two configurable environment variables: 
+There are two configurable environment variables:
 * `CONGRESS_EXCLUDES`: a comma separated list of namespaces to exclude from network isolation (default: `"kube-system"`). Example: `"kube-system,default,myImportantNamespace,anotherImportantNamspace"`
 * `CONGRESS_SELECTOR`: the label selector used by the watcher to filter `Namespace` events by (default: `""` i.e. all namespaces).
   Example: `"company=apigee,env=test"`

--- a/congress.yaml
+++ b/congress.yaml
@@ -13,6 +13,6 @@ spec:
         name: congress
     spec:
       containers:
-      - image: thirtyx/congress:0.1.0
+      - image: thirtyx/congress:0.1.1
         imagePullPolicy: Always
         name: congress

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -37,9 +37,8 @@ const (
   ApigeeNamespaceName = "apigee"
 )
 
-// IsolateNamespace adds the network isolation annotation to the namespace and necessary label
+// IsolateNamespace adds the necessary label for network isolation
 func IsolateNamespace(client *unversioned.Client, namespace *api.Namespace) error {
-  addIngressAnnotation(namespace)
   addNameLabel(namespace)
 
   _ , err := client.Namespaces().Update(namespace)
@@ -61,21 +60,6 @@ func addNameLabel(namespace *api.Namespace) {
   // add `name` label with this namespace's name
   labels[NameLabelKey] = namespace.Name
   namespace.SetLabels(labels)
-}
-
-func addIngressAnnotation(namespace *api.Namespace) {
-  annotations := namespace.GetAnnotations()
-  if annotations == nil { // no annotations
-    annotations = map[string]string{}
-  } else if _, exists := annotations[IngressAnnotationKey]; exists {
-    return // annotation already exists
-  }
-
-  // annotation does not exist, add it
-  annotations[IngressAnnotationKey] = IngressAnnotationValue
-  namespace.SetAnnotations(annotations)
-
-  return
 }
 
 // EnactPolicies creates the necessary network policies in the given namespace

--- a/policy/validate.go
+++ b/policy/validate.go
@@ -34,7 +34,9 @@ func ValidateList(client *unversioned.Client, extClient *unversioned.ExtensionsC
     }
   }
 
-  list, err := client.Namespaces().List(api.ListOptions{})
+  list, err := client.Namespaces().List(api.ListOptions{
+    LabelSelector: config.LabelSelector,
+  })
   if err != nil {
     return nil, err
   }


### PR DESCRIPTION
Fixes #6 

creation of new namespaces no longer adds the `ingress: isolation: {}` annotation (moved to `enrober`), but still validates on modifications that the annotation is valid.
