### PR TITLE
repeal iso policies on exclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_VERSION=0.1.3
+IMAGE_VERSION=0.1.4
 
 build-and-package: compile-linux build-image
 build-deploy-dev: compile-linux build-image push-to-dev deploy-dev-image
@@ -18,4 +18,7 @@ push-new-version:
 	docker push thirtyx/congress:$(IMAGE_VERSION)
 
 deploy-dev-image:
-	kubectl create -f congress-dev.yaml  --namespace=apigee
+	kubectl replace -f congress-dev.yaml  --namespace=apigee
+
+clean:
+	rm congress

--- a/congress.yaml
+++ b/congress.yaml
@@ -13,7 +13,7 @@ spec:
         name: congress
     spec:
       containers:
-      - image: thirtyx/congress:0.1.3
+      - image: thirtyx/congress:0.1.4
         imagePullPolicy: Always
         name: congress
         env:

--- a/main.go
+++ b/main.go
@@ -89,6 +89,13 @@ func main() {
         if err != nil {
           log.Printf("Failed validating modified namespace %s: %v", namespace.Name, err)
         }
+      } else if config.InIgnoreSelector(namespace.GetLabels()) && namespace.Status.Phase == api.NamespaceActive {
+        // this namespace might be newly excluded, ensure it is exposed
+        log.Printf("Modification on excluded namespace: %s. Ensuring it isn't isolated.", namespace.Name)
+        err = policy.ValidateIsolation(kubeClient, extClient, namespace, config)
+        if err != nil {
+          log.Printf("Failed validating isolation of excluded namespace: %s err: %v", namespace.Name, err)
+        }
       }
     }
 


### PR DESCRIPTION
fixes #10 
- when a namespace is given an `CONGRESS_IGNORE_SELECTOR` label, all previously done network isolation will be repealed, exposing the namespace and its pods entirely.
